### PR TITLE
Implementation of Biquad filters

### DIFF
--- a/modules/filters/biquadFilter.c
+++ b/modules/filters/biquadFilter.c
@@ -1,0 +1,87 @@
+#ifndef __BIQUAD_FILTER_C__
+#define __BIQUAD_FILTER_C__
+
+#pragma systemFile
+
+#ifndef __BIQUAD_FILTERS_H__
+#include "biquadFilters.h"
+#endif
+
+int BiquadFilterInit(
+    struct BiquadFilter* filter,
+    enum BiquadFilterType type,
+    float sampleFreq,
+    float cutoffFreq,
+    float defaultValue)
+{
+  if (filter == 0) return -1;
+
+  float w0 = 2 * PI * cutoffFreq / sampleFreq;
+  float cosw0 = cos(w0);
+  float sinw0 = sin(w0);
+
+  float Q = 0.707;
+  float alpha = sinw0 / (2 * Q);
+  float b0, b1, b2, a0, a1, a2;
+
+  writeDebugStreamLine("%f %f %f %f", cosw0, sinw0, alpha, Q);
+
+  // Calculates the coefficients for the transfer function.
+  switch (type)
+  {
+    case LOWPASS:
+      b0 = (1 - cosw0) / 2;
+      b1 = (1 - cosw0);
+      b2 = (1 - cosw0) / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosw0;
+      a2 = 1 - alpha;
+      break;
+
+    case HIGHPASS:
+      b0 = (1 + cosw0) / 2;
+      b1 = -(1 + cosw0);
+      b2 = (1 + cosw0) / 2;
+      a0 = 1 + alpha;
+      a1 = -2 * cosw0;
+      a2 = 1 - alpha;
+      break;
+
+    default:
+      return -1;
+  }
+
+  // Normalize the coefficients so that a0 = 1.
+  filter->b0 = b0 / a0;
+  filter->b1 = b1 / a0;
+  filter->b2 = b2 / a0;
+  filter->a1 = a1 / a0;
+  filter->a2 = a2 / a0;
+
+  filter->old_input[0] = filter->old_input[1] = defaultValue;
+  filter->old_output[0] = filter->old_output[1] = defaultValue;
+
+  return 0;
+}
+
+float BiquadFilterSample(struct BiquadFilter* filter, float data)
+{
+  if (filter == 0) return -1;
+
+  float output =
+    filter->b0 * data +
+    filter->b1 * filter->old_input[0] +
+    filter->b2 * filter->old_input[1] -
+    filter->a1 * filter->old_output[0] -
+    filter->a2 * filter->old_output[1];
+
+  filter->old_input[1] = filter->old_input[0];
+  filter->old_input[0] = data;
+
+  filter->old_output[1] = filter->old_output[0];
+  filter->old_output[0] = output;
+
+  return output;
+}
+
+#endif

--- a/modules/filters/biquadFilters.h
+++ b/modules/filters/biquadFilters.h
@@ -1,0 +1,39 @@
+#ifndef __BIQUAD_FILTERS_H__
+#define __BIQUAD_FILTERS_H__
+
+// Biquad filter is a standard 2nd-order filter
+// The transfer function follows the following format:
+// H(z) = (b0 + b1*z^-1 + b2*z^-2) / (1 + a1*z^-1 + a2*z^-2)
+struct BiquadFilter
+{
+  float b0, b1, b2, a1, a2;
+
+  float old_input[2];
+  float old_output[2];
+};
+
+// The response of the filter, default is butterworth.
+enum BiquadFilterType
+{
+  LOWPASS,
+  HIGHPASS
+};
+
+// Initializes biquad filter.
+// Sample Freq and cutoff freq is in hertz.
+// Ex. If you sample a gyroscope 100 times a second, sample
+//     freq is 100 and cutoff freq is the -3db point for the
+//     filter, such as 40.
+int BiquadFilterInit(
+    struct BiquadFilter* filter,
+    enum BiquadFilterType type,
+    float sampleFreq,
+    float cutoffFreq,
+    float defaultValue = 0.0);
+
+// Takes sensor input and returns a filtered value.
+float BiquadFilterSample(struct BiquadFilter* filter, float data);
+
+#include "biquadFilter.c"
+
+#endif

--- a/modules/filters/examples/biquadFilterExample.c
+++ b/modules/filters/examples/biquadFilterExample.c
@@ -1,0 +1,35 @@
+#include "../biquadFilters.h"
+
+task main
+{
+  struct BiquadFilter filter;
+
+  // Initialize biquad filter as lowpass butterworth.
+  // Sample 10 times a second, -3db cutoff freq of 1Hz
+  BiquadFilterInit(&filter, LOWPASS, 10, 0.5);
+
+  writeDebugStreamLine("Biquad filter example.  ");
+  writeDebugStreamLine("Copy and paste results into excel and graph results");
+  writeDebugStreamLine(
+    "H(z) = (%f + %f*z^-1 + %f*z^-2) / (1 + %f*z^-1 + %f*z^-2)",
+    filter.b0, filter.b1, filter.b2, filter.a1, filter.a2);
+
+  // This mimics "noisy sensor data".
+  float data[100];
+  for (int i = 0; i < 100; i++)
+  {
+    // Main signal
+    data[i] = sin(0.5 * PI * i / 10.0 ) +
+      // "Noise"
+      sin(3.6 * PI * i / 10.0) +
+      sin(5.8 * PI * i / 10.0);
+  }
+
+  // Apply low pass filter to noisy sensor data.
+  int i;
+  for (i = 0; i < 100; i++)
+  {
+    float x = BiquadFilterSample(&filter, data[i]);
+    writeDebugStreamLine("%f %f", data[i], x);
+  }
+}

--- a/modules/filters/info.txt
+++ b/modules/filters/info.txt
@@ -1,0 +1,11 @@
+# Filters:
+
+## Biquad Filter: 
+ - Best used for filtering gyroscope/accelerometer data.
+ - int BiquadFilterInit(...) initializes the filter
+   - `type` can be either LOWPASS or HIGHPASS 
+   - `sampleFreq` is the sampling frequency. Ex. 100 if sampling 100 times a second.
+   - `cutoffFreq` is the -3db frequency for the filter.  
+   - `defaultValue` is the first value to be saved into the filter.  Default to 0.
+   - NOTE: samplingFreq should not be less then the cutoffFreq.
+ - float BiquadFilterSample(...) takes a sample and returns a filtered value.


### PR DESCRIPTION
Implements a typical biquad filter, best used for filtering gyroscope and accelerometer data.  
